### PR TITLE
Make script more compatible (works with nixos now)

### DIFF
--- a/lua/fzf-lua-enchanted-files/init.lua
+++ b/lua/fzf-lua-enchanted-files/init.lua
@@ -170,7 +170,7 @@ function M.files(opts)
       
       -- Create a script that shows recent files first, then all others EXCEPT the recent ones
       local temp_script = vim.fn.tempname() .. ".sh"
-      local script_content = string.format([[#!/bin/bash
+      local script_content = string.format([[#!/usr/bin/env bash
 # Show recent files first
 %s
 # Show all other files, excluding the recent ones


### PR DESCRIPTION
this plugin did not work with nixos as the embedded script uses /bin/bash which is not compatible with nixos but using /usr/bin/env bash is more compatible with nixos/macos/bsd .
/usr/bin/env is less efficient but I do not think it will be noticable difference